### PR TITLE
Build GitHub release binary with cross

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,11 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Build
-        run: cargo build --release
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          use-cross: true
+          args: --release
 
       - name: Display checksum
         run: shasum -a 256 target/release/notion-generator


### PR DESCRIPTION
This allows older Linux distros to use the binary since `cross` compiles
the binary with a dependency on glibc 2.18 instead of the glibc shipped
with Ubuntu 20.04