### PR TITLE
Create media directory if it doesn't exist

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -41,6 +41,8 @@ impl Downloadables {
     }
 
     pub async fn download_all(self, client: &Client, output: &Path) -> Result<()> {
+        tokio::fs::create_dir(output.join(FILES_DIR)).await?;
+
         let write_operations = self
             .list
             .into_iter()


### PR DESCRIPTION
The decision to use `create_dir` instead of `create_dir_all` was a
conscience one. I don't think we should be creating the output dir
because that could cause a person to create incorrect directories by
mistake that they didn't intend to i.e using --output=/abc instead of
the intended --output=abc
This is the same behavior curl takes with its --output-dir option.