### PR TITLE
Add initial support for RichText mentions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "clap",
+ "either",
  "emoji",
  "futures-util",
  "itertools 0.10.1",
@@ -661,6 +662,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "time",
  "tokio",
  "tree-sitter",
  "tree-sitter-highlight",
@@ -683,6 +685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f14f385fd31045b0555b7656038b9609e3b7a67f0c68e3435c0a7361f813573"
+dependencies = [
  "libc",
 ]
 
@@ -1187,6 +1198,22 @@ checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.5"
+source = "git+https://github.com/Mathspy/time?branch=fmt-write#b12596c649ed8cff2db7b006b3056989673fcbe8"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "git+https://github.com/Mathspy/time?branch=fmt-write#b12596c649ed8cff2db7b006b3056989673fcbe8"
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ rust-version = "1.57"
 [dependencies]
 anyhow = { version = "1" }
 async-recursion = { version = "0.3" }
+time = { git = "https://github.com/Mathspy/time", branch = "fmt-write", features = ["formatting", "parsing", "macros"] }
 clap = { version = "3.0.0-beta.5" }
+either = { version = "1" }
 emoji = { version = "0.2" }
 futures-util = { version = "0.3" }
 itertools = { version = "0.10" }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,6 @@
+use either::Either;
 use serde::{Deserialize, Serialize};
+use time::{Date, OffsetDateTime};
 
 // ------------------ NOTION ERROR OBJECT ------------------
 // As defined in https://developers.notion.com/reference/errors
@@ -60,8 +62,10 @@ pub enum RichTextType {
     Equation {
         expression: String,
     },
-    // TODO: Handle Mention
-    // Mention
+    Mention {
+        #[serde(flatten)]
+        mention: RichTextMentionType,
+    },
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -69,6 +73,70 @@ pub struct RichTextLink {
     // TODO(NOTION): Notion docs say type: "url" should be returned but it's not
     // type: "url",
     pub url: String,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Time {
+    // We keep the original to avoid needing to recreate it if we need an ISO 8601 formatted
+    // date(time) later
+    pub original: String,
+    pub parsed: Either<Date, OffsetDateTime>,
+}
+
+mod deserializers {
+    use super::Time;
+    use either::Either;
+    use serde::{de::Error, Deserialize, Deserializer};
+    use time::{
+        format_description::{well_known::Rfc3339, FormatItem},
+        macros::format_description,
+        Date, OffsetDateTime,
+    };
+
+    const DATE_FORMAT: &[FormatItem<'_>] = format_description!("[year]-[month]-[day]");
+
+    fn inner<'a, D: Deserializer<'a>>(input: String) -> Result<Time, D::Error> {
+        if let Ok(date) = Date::parse(&input, DATE_FORMAT) {
+            return Ok(Time {
+                original: input,
+                parsed: Either::Left(date),
+            });
+        }
+
+        if let Ok(datetime) = OffsetDateTime::parse(&input, &Rfc3339) {
+            return Ok(Time {
+                original: input,
+                parsed: Either::Right(datetime),
+            });
+        }
+
+        Err(D::Error::custom(
+            "data matched neither a date (YYYY-MM-DD) nor a datetime (RFC3339)",
+        ))
+    }
+
+    pub fn time<'a, D: Deserializer<'a>>(deserializer: D) -> Result<Time, D::Error> {
+        inner::<D>(<_>::deserialize(deserializer)?)
+    }
+
+    pub fn optional_time<'a, D: Deserializer<'a>>(
+        deserializer: D,
+    ) -> Result<Option<Time>, D::Error> {
+        Option::deserialize(deserializer)?
+            .map(inner::<D>)
+            .transpose()
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RichTextMentionType {
+    Date {
+        #[serde(deserialize_with = "deserializers::time")]
+        start: Time,
+        #[serde(deserialize_with = "deserializers::optional_time")]
+        end: Option<Time>,
+    },
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]
@@ -448,9 +516,11 @@ pub enum EmojiOrFile {
 mod tests {
     use super::{
         Block, BlockType, Emoji, EmojiOrFile, Error, ErrorCode, File, Language, List, RichText,
-        RichTextType,
+        RichTextMentionType, RichTextType, Time,
     };
+    use either::Either;
     use pretty_assertions::assert_eq;
+    use time::macros::{date, datetime};
 
     #[test]
     fn test_errors() {
@@ -545,6 +615,94 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<ErrorCode>(json).unwrap(),
             ErrorCode::Unknown
+        );
+    }
+
+    #[test]
+    fn test_rich_text_mentions() {
+        let json = r#"
+            {
+              "type": "mention",
+              "mention": {
+                "type": "date",
+                "date": {
+                  "start": "2021-11-07T02:59:00.000-08:00",
+                  "end": null
+                }
+              },
+              "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+              },
+              "plain_text": "2021-11-07T02:59:00.000-08:00 → ",
+              "href": null
+            }
+        "#;
+
+        assert_eq!(
+            serde_json::from_str::<RichText>(json).unwrap(),
+            RichText {
+                plain_text: "2021-11-07T02:59:00.000-08:00 → ".to_string(),
+                href: None,
+                annotations: Default::default(),
+                ty: RichTextType::Mention {
+                    mention: RichTextMentionType::Date {
+                        start: Time {
+                            original: "2021-11-07T02:59:00.000-08:00".to_string(),
+                            parsed: Either::Right(datetime!(2021-11-07 10:59 UTC))
+                        },
+                        end: None,
+                    },
+                },
+            }
+        );
+
+        let json = r#"
+            {
+              "type": "mention",
+              "mention": {
+                "type": "date",
+                "date": {
+                  "start": "2021-12-05",
+                  "end": "2021-12-06"
+                }
+              },
+              "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+              },
+              "plain_text": "2021-12-05 → 2021-12-06",
+              "href": null
+            }
+        "#;
+
+        assert_eq!(
+            serde_json::from_str::<RichText>(json).unwrap(),
+            RichText {
+                plain_text: "2021-12-05 → 2021-12-06".to_string(),
+                href: None,
+                annotations: Default::default(),
+                ty: RichTextType::Mention {
+                    mention: RichTextMentionType::Date {
+                        start: Time {
+                            original: "2021-12-05".to_string(),
+                            parsed: Either::Left(date!(2021 - 12 - 05))
+                        },
+                        end: Some(Time {
+                            original: "2021-12-06".to_string(),
+                            parsed: Either::Left(date!(2021 - 12 - 06))
+                        }),
+                    },
+                },
+            }
         );
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -139,12 +139,19 @@ pub enum RichTextMentionType {
         #[serde(flatten)]
         ty: UserType,
     },
+    Page {
+        id: String,
+    },
+    Database {
+        id: String,
+    },
     Date {
         #[serde(deserialize_with = "deserializers::time")]
         start: Time,
         #[serde(deserialize_with = "deserializers::optional_time")]
         end: Option<Time>,
     },
+    // TODO(NOTION): link_preview has absolutely no documentation
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -764,6 +771,78 @@ mod tests {
                         ty: UserType::Person {
                             email: "spam@example.com".to_string(),
                         }
+                    },
+                },
+            }
+        );
+
+        let json = r#"
+                        {
+              "type": "mention",
+              "mention": {
+                "type": "page",
+                "page": {
+                  "id": "6e0eb85f-6047-4efb-a130-4f92d2abfa2c"
+                }
+              },
+              "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+              },
+              "plain_text": "watereddown-test",
+              "href": "https://www.notion.so/6e0eb85f60474efba1304f92d2abfa2c"
+            }
+        "#;
+
+        assert_eq!(
+            serde_json::from_str::<RichText>(json).unwrap(),
+            RichText {
+                plain_text: "watereddown-test".to_string(),
+                href: Some("https://www.notion.so/6e0eb85f60474efba1304f92d2abfa2c".to_string()),
+                annotations: Default::default(),
+                ty: RichTextType::Mention {
+                    mention: RichTextMentionType::Page {
+                        id: "6e0eb85f-6047-4efb-a130-4f92d2abfa2c".to_string(),
+                    },
+                },
+            }
+        );
+
+        let json = r#"
+            {
+              "type": "mention",
+              "mention": {
+                "type": "database",
+                "database": {
+                  "id": "332b7b05-2ded-4955-bc77-60851242836a"
+                }
+              },
+              "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+              },
+              "plain_text": "Some whacky database",
+              "href": "https://www.notion.so/332b7b052ded4955bc7760851242836a"
+            }
+        "#;
+
+        assert_eq!(
+            serde_json::from_str::<RichText>(json).unwrap(),
+            RichText {
+                plain_text: "Some whacky database".to_string(),
+                href: Some("https://www.notion.so/332b7b052ded4955bc7760851242836a".to_string()),
+                annotations: Default::default(),
+                ty: RichTextType::Mention {
+                    mention: RichTextMentionType::Database {
+                        id: "332b7b05-2ded-4955-bc77-60851242836a".to_string(),
                     },
                 },
             }


### PR DESCRIPTION
This adds support for deserializing all types of mention besides `link_preview` (since there are no docs for that and I am not sure how to create one in Notion itself). It also adds html rendering support for `date` mentions with `page` and `database` to follow up in another PR that adds proper support for links in general