### PR TITLE
PlainText trait

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -52,6 +52,10 @@ pub struct RichText {
     pub ty: RichTextType,
 }
 
+pub trait PlainText {
+    fn plain_text(&self) -> String;
+}
+
 mod deserializers {
     use super::{RichTextLink, Time};
     use either::Either;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,5 @@
 use either::Either;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use time::{Date, OffsetDateTime};
 
@@ -54,6 +55,12 @@ pub struct RichText {
 
 pub trait PlainText {
     fn plain_text(&self) -> String;
+}
+
+impl PlainText for &[RichText] {
+    fn plain_text(&self) -> String {
+        self.iter().map(|rich_text| &rich_text.plain_text).join("")
+    }
 }
 
 mod deserializers {


### PR DESCRIPTION
A trait to allow extracting `plain_text` from different types of RichText easily