### PR TITLE
Improve composability of highlight classes 

### DIFF
--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -61,7 +61,7 @@ pub fn highlight(lang: &Language, code: &str, id: NotionId) -> Result<Markup> {
         .unwrap();
 
     let classes = HIGHLIGHTS
-        .map(|highlight| format!(r#"class="{}""#, highlight.replace(".", "-")).into_bytes());
+        .map(|highlight| format!(r#"class="{}""#, highlight.replace(".", " ")).into_bytes());
 
     renderer
         .render(events, code.as_bytes(), &|highlight| &classes[highlight.0])
@@ -110,7 +110,7 @@ I hope you have a great day!</code></pre>"#
             )
             .unwrap()
             .into_string(),
-            r#"<pre id="5e845049255f423296fd6f20449be0bc" class="rust"><code class="rust"><span class="keyword">const</span> <span class="variable">x</span>: <span class="operator">&amp;</span><span class="type-builtin">str</span> <span class="operator">=</span> <span class="string">&quot;abc&quot;</span><span class="punctuation">;</span>
+            r#"<pre id="5e845049255f423296fd6f20449be0bc" class="rust"><code class="rust"><span class="keyword">const</span> <span class="variable">x</span>: <span class="operator">&amp;</span><span class="type builtin">str</span> <span class="operator">=</span> <span class="string">&quot;abc&quot;</span><span class="punctuation">;</span>
 </code></pre>"#
         );
     }

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -99,4 +99,19 @@ mod tests {
 I hope you have a great day!</code></pre>"#
         );
     }
+
+    #[test]
+    fn rust_type_builtin() {
+        assert_eq!(
+            highlight(
+                &Language::Rust,
+                r#"const x: &str = "abc";"#,
+                "5e845049255f423296fd6f20449be0bc".parse().unwrap()
+            )
+            .unwrap()
+            .into_string(),
+            r#"<pre id="5e845049255f423296fd6f20449be0bc" class="rust"><code class="rust"><span class="keyword">const</span> <span class="variable">x</span>: <span class="operator">&amp;</span><span class="type-builtin">str</span> <span class="operator">=</span> <span class="string">&quot;abc&quot;</span><span class="punctuation">;</span>
+</code></pre>"#
+        );
+    }
 }


### PR DESCRIPTION
Instead of the class `type-builtin` we will add the two classes `type`
and `builtin` because this gives us MUCH more composability
If we want to target only types that are builtin we can do
`.type.builtin`, if we want only types that aren't builtin we can do
`.type:not(.builtin)`