### PR TITLE
Add support for TOML by using out-of-band info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-highlight",
  "tree-sitter-rust",
+ "tree-sitter-toml",
  "uuid",
 ]
 
@@ -1527,6 +1528,16 @@ name = "tree-sitter-rust"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df540a493d754015d22eaf57c38f58804be3713a22f6062db983ec15f85c3c9"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-toml"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1", features = ["fs"] }
 tree-sitter = { version = "0.20" }
 tree-sitter-highlight = { version = "0.20" }
 tree-sitter-rust = { version = "0.20" }
+tree-sitter-toml = { version = "0.20" }
 uuid = { version = "0.8", features = ["serde"] }
 tower = { version = "0.4", features = ["buffer", "limit", "util"] }
 


### PR DESCRIPTION
TOML is fairly essential for describing Rust related configuration and
when a website doesn't have highlighting it feels like not enough
effort was put into it. We can't let ourselves be that!
And I am not going to sit tight until Notion adds support for TOML so
I am taking matters into my own hand by adding support for TOML using a
special marker that is unlikely to appear in that specific format
anywhere else