### PR TITLE
Refactored Time to hide its implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,6 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-recursion",
- "either",
  "emoji",
  "flurry",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = "1.57"
 anyhow = { version = "1" }
 async-recursion = { version = "0.3" }
 time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
-either = { version = "1" }
 emoji = { version = "0.2" }
 flurry = { version = "0.3" }
 futures-util = { version = "0.3" }

--- a/src/render.rs
+++ b/src/render.rs
@@ -726,10 +726,9 @@ mod tests {
         response::{
             properties::TitleProperty, Annotations, Block, BlockType, Color, Emoji, EmojiOrFile,
             File, Language, NotionDate, Page, PageParent, RichText, RichTextLink,
-            RichTextMentionType, RichTextType, Time,
+            RichTextMentionType, RichTextType,
         },
     };
-    use either::Either;
     use maud::Render;
     use pretty_assertions::assert_eq;
     use reqwest::Url;
@@ -737,7 +736,6 @@ mod tests {
         collections::{HashMap, HashSet},
         path::PathBuf,
     };
-    use time::macros::{date, datetime};
 
     #[test]
     fn render_unsupported() {
@@ -1993,10 +1991,7 @@ mod tests {
             annotations: Default::default(),
             ty: RichTextType::Mention {
                 mention: RichTextMentionType::Date(NotionDate {
-                    start: Time {
-                        original: "2021-11-07T02:59:00.000-08:00".to_string(),
-                        parsed: Either::Right(datetime!(2021-11-07 02:59-08:00)),
-                    },
+                    start: "2021-11-07T02:59:00.000-08:00".parse().unwrap(),
                     end: None,
                     time_zone: None,
                 }),
@@ -2016,14 +2011,8 @@ mod tests {
             annotations: Default::default(),
             ty: RichTextType::Mention {
                 mention: RichTextMentionType::Date(NotionDate {
-                    start: Time {
-                        original: "2021-12-05".to_string(),
-                        parsed: Either::Left(date!(2021 - 12 - 05)),
-                    },
-                    end: Some(Time {
-                        original: "2021-12-06".to_string(),
-                        parsed: Either::Left(date!(2021 - 12 - 06)),
-                    }),
+                    start: "2021-12-05".parse().unwrap(),
+                    end: Some("2021-12-06".parse().unwrap()),
                     time_zone: None,
                 }),
             },

--- a/src/response.rs
+++ b/src/response.rs
@@ -270,8 +270,10 @@ impl PartialEq<TimeInner> for TimeInner {
     }
 }
 
-// TODO: The original and parsed shouldn't really be pub and instead should use getter methods to
-// ensure they stay in sync and can't be changed in an invalid way
+/// Time data from Notion.
+///
+/// Notion Times can either be dates or datetimes, this information is perserved internally
+/// and exposed via the utility methods available on Time
 #[derive(Debug, Eq, Clone)]
 pub struct Time {
     // We keep the original to avoid needing to recreate it if we need an ISO 8601 formatted
@@ -281,6 +283,10 @@ pub struct Time {
 }
 
 impl Time {
+    /// Get date infalliable.
+    ///
+    /// If `Time` is a date it will be returned, otherwise if it's a datetime it will truncate the
+    /// time part of datetime and return the date
     pub fn date(&self) -> Date {
         match self.parsed {
             TimeInner::Date(date) => date,
@@ -288,6 +294,10 @@ impl Time {
         }
     }
 
+    /// Get datetime infalliable.
+    ///
+    /// If `Time` is a datetime it will be returned, otherwise if it's a date it will extend the date
+    /// by considering time to be midnight and timezone to be UTC
     pub fn datetime(&self) -> OffsetDateTime {
         match self.parsed {
             TimeInner::Date(date) => date.with_time(time::Time::MIDNIGHT).assume_utc(),
@@ -295,6 +305,7 @@ impl Time {
         }
     }
 
+    /// Get date if the `Time` is date otherwise will return an `Err(OffsetDateTime)`
     pub fn get_date(&self) -> Result<Date, OffsetDateTime> {
         match self.parsed {
             TimeInner::Date(date) => Ok(date),
@@ -302,6 +313,7 @@ impl Time {
         }
     }
 
+    /// Get datetime if the `Time` is datetime otherwise will return an `Err(Date)`
     pub fn get_datetime(&self) -> Result<OffsetDateTime, Date> {
         match self.parsed {
             TimeInner::Date(date) => Err(date),
@@ -309,6 +321,7 @@ impl Time {
         }
     }
 
+    /// Returns the original time string that it was parsed from
     pub fn original(&self) -> &str {
         &self.original
     }


### PR DESCRIPTION
This ensures that original will always be correct since Time cannot be constructed except via .parse() and cannot be edited after construction